### PR TITLE
ci(sonar): manual dispatch uses fast compile-only analysis, not the 3h coverage build

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -27,10 +27,15 @@ env:
     -pl !distribution/docs,!distribution/ddf,!distribution/docker/ddf-docker
 
 jobs:
-  # Compile-only analysis for push/PR events (fast feedback, no coverage)
+  # Compile-only analysis for push/PR/manual events (fast feedback, no coverage).
+  # Manual dispatch uses this fast path so it reliably reaches the sonar:sonar
+  # upload; the full coverage build (below) is reserved for the nightly schedule
+  # because it runs the whole-reactor test suite and can exceed the job timeout.
   analysis:
     name: SonarCloud Analysis (Compile Only)
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'push' || github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -69,10 +74,11 @@ jobs:
           mvn $MAVEN_CLI_OPTS sonar:sonar \
             $DISTRO_EXCLUDES
 
-  # Full analysis with tests + JaCoCo coverage for nightly/manual runs
+  # Full analysis with tests + JaCoCo coverage for the nightly schedule only.
+  # (Manual runs use the fast compile-only job above to avoid the 180-min timeout.)
   analysis-with-coverage:
     name: SonarCloud Analysis (With Coverage)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 180
 


### PR DESCRIPTION
## Summary

Manual SonarCloud runs were unusable: a `workflow_dispatch` routes to the `analysis-with-coverage` job, which runs the **whole-reactor test suite + JaCoCo** and exceeds its 180-minute timeout — so `sonar:sonar` never uploads and the project dashboard stays empty (observed: run 27352815218 cancelled at the timeout).

## Change

- Route `workflow_dispatch` (and keep `push`/`pull_request`) to the **compile-only** `analysis` job, which finishes in ~10 minutes and reliably reaches the upload step.
- Reserve the full coverage build for the **nightly `schedule`** only.

No analysis quality is lost for manual/push runs (they were already compile-only on push/PR); this just stops manual runs from kicking off a 3-hour job that can't finish.

## Why now

After the SonarCloud project's main branch was corrected to `main`, the dashboard needs one successful analysis to populate. Merging this PR triggers a push-event compile-only analysis on `main`, which both validates the fix and populates the dashboard (bugs/vulns/hotspots/code-smells). Coverage will fill in on the next nightly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run compile-only analysis on manual triggers and regular events
  * Restricted coverage analysis to nightly scheduled runs for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->